### PR TITLE
fix: remove invalid --dev flag from expo start

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "ios": "expo run:ios",
     "lint": "eslint .",
     "start": "node scripts/start.js",
-    "dev": "npx expo start --dev",
+    "dev": "npx expo start",
     "docs:generate": "typedoc --options typedoc.json",
     "docs:convert": "node scripts/convert-to-mintlify.js",
     "check-env": "node scripts/check-env.js"


### PR DESCRIPTION
### What this PR fixes

Removes the `--dev` flag from the `dev` script in `package.json`, which currently causes an error when running `pnpm dev`:

```
unknown or unexpected option: --dev
```

### Why

`expo start` no longer supports the `--dev` flag. Removing it ensures that the project runs correctly out of the box with `pnpm dev`.

---

**Note:** I understand this PR does not qualify as a module per the contribution guidelines. However, it fixes a critical issue in the project setup, preventing new contributors from running the app successfully. Please let me know if you'd prefer this change be submitted as part of a broader starter improvement module instead.